### PR TITLE
Removed useless 'g' letter

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
 
 	<meta name="description" content="The Jungle EOIO Testnet">
 	<meta name="author" content="Jungle Testnet Community">
-	<!-- META DATA -->g
+	<!-- META DATA -->
 	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
 
 	<!-- =========================


### PR DESCRIPTION
There's a character at the top of the page moving all the content down leaving a big white space at the top. This PR just removes it.